### PR TITLE
Attachment support

### DIFF
--- a/Mailer.php
+++ b/Mailer.php
@@ -170,12 +170,6 @@ class Mailer extends BaseMailer
 
         $response = $this->_mailjet->post(Resources::$Email, ['body' => $body]);
         $this->_response = $response;
-
-        var_dump('Response from Mailjet API: ' . $response->getStatus() .' - '. $response->getReasonPhrase() . ' - ' . serialize($response->getData()));
-        echo "<hr>"; var_dump($body); echo "<hr>";
-        exit;
-
-
         return $response->success();
     }
 

--- a/Mailer.php
+++ b/Mailer.php
@@ -154,6 +154,12 @@ class Mailer extends BaseMailer
             'Html-part' => $message->htmlBody,
             'Recipients' => $recipients,
         ];
+        if ($message->attachments) {
+            $body['Attachments'] = $message->attachments;
+        }
+        if ($message->inlineAttachments) {
+            $body['InlinedAttachments'] = $message->inlineAttachments;
+        }
 
         //Adds Reply-To to header
         if(!empty($message->replyTo)){

--- a/Mailer.php
+++ b/Mailer.php
@@ -163,14 +163,14 @@ class Mailer extends BaseMailer
             'Subject' => $message->subject,
             'Text-part' => $message->textBody,
             'Html-part' => $message->htmlBody,
-            'To' => $to,
+            'To' => join(', ',$to),
         ];
 
         if ($cc) {
-            $body['Cc'] = $cc;
+            $body['Cc'] = join(', ',$cc);
         }
         if ($bcc) {
-            $body['Bcc'] = $bcc;
+            $body['Bcc'] = join(', ', $bcc);
         }
 
         if ($message->attachments) {

--- a/Mailer.php
+++ b/Mailer.php
@@ -170,7 +170,7 @@ class Mailer extends BaseMailer
 
         $response = $this->_mailjet->post(Resources::$Email, ['body' => $body]);
         $this->_response = $response;
-        Yii::debug('Response from Mailjet API: ' . serialize($response));
+        \Yii::debug('Response from Mailjet API: ' . $response->getReasonPhrase() . ' - ' . serialize($response->getData()));
         return $response->success();
     }
 

--- a/Mailer.php
+++ b/Mailer.php
@@ -170,7 +170,12 @@ class Mailer extends BaseMailer
 
         $response = $this->_mailjet->post(Resources::$Email, ['body' => $body]);
         $this->_response = $response;
-        \Yii::debug('Response from Mailjet API: ' . $response->getReasonPhrase() . ' - ' . serialize($response->getData()));
+
+        var_dump('Response from Mailjet API: ' . $response->getStatus() .' - '. $response->getReasonPhrase() . ' - ' . serialize($response->getData()));
+        echo "<hr>"; var_dump($body); echo "<hr>";
+        exit;
+
+
         return $response->success();
     }
 

--- a/Mailer.php
+++ b/Mailer.php
@@ -131,29 +131,48 @@ class Mailer extends BaseMailer
     protected function sendMessage($message)
     {
 
-        $recipients = [];
+        $to = $cc = $bcc = [];
 
         foreach ($message->to as $email => $name) {
-
-            $newRecipient = [];
-
-            if (!empty($email)) {
-                $newRecipient['Email'] = $email;
-            }
-
+            $address = '<' . $email . '>';
             if (!empty($name)) {
-                $newRecipient['Name'] = $name;
+                $address = '"' . $name . '" ' . $address;
             }
-
-            $recipients[] = $newRecipient;
+            $to[] = $address;
         }
+
+        foreach ($message->cc as $email => $name) {
+            $address = '<' . $email . '>';
+            if (!empty($name)) {
+                $address = '"' . $name . '" ' . $address;
+            }
+            $cc[] = $address;
+        }
+
+
+        foreach ($message->bcc as $email => $name) {
+            $address = '<' . $email . '>';
+            if (!empty($name)) {
+                $address = '"' . $name . '" ' . $address;
+            }
+            $bcc[] = $address;
+        }
+
 
         $body = [
             'Subject' => $message->subject,
             'Text-part' => $message->textBody,
             'Html-part' => $message->htmlBody,
-            'Recipients' => $recipients,
+            'To' => $to,
         ];
+
+        if ($cc) {
+            $body['Cc'] = $cc;
+        }
+        if ($bcc) {
+            $body['Bcc'] = $bcc;
+        }
+
         if ($message->attachments) {
             $body['Attachments'] = $message->attachments;
         }

--- a/Mailer.php
+++ b/Mailer.php
@@ -177,11 +177,11 @@ class Mailer extends BaseMailer
             $body['Attachments'] = $message->attachments;
         }
         if ($message->inlineAttachments) {
-            $body['InlinedAttachments'] = $message->inlineAttachments;
+            $body['Inline_attachments'] = $message->inlineAttachments;
         }
 
         //Adds Reply-To to header
-        if(!empty($message->replyTo)){
+        if(!empty($message->replyTo)) {
             $body['Headers']['Reply-to'] = $message->replyTo;
         }
 

--- a/Mailer.php
+++ b/Mailer.php
@@ -170,6 +170,7 @@ class Mailer extends BaseMailer
 
         $response = $this->_mailjet->post(Resources::$Email, ['body' => $body]);
         $this->_response = $response;
+        Yii::debug('Response from Mailjet API: ' . serialize($response));
         return $response->success();
     }
 

--- a/Message.php
+++ b/Message.php
@@ -223,7 +223,7 @@ class Message extends BaseMessage {
             'content' => base64_encode(file_get_contents($fileName)),
         ];
         $this->_inline_attachments[] = $attachment;
-        return $attachment['Filename'];
+        return 'cid:' . $attachment['Filename'];
     }
 
     /**
@@ -236,7 +236,7 @@ class Message extends BaseMessage {
             'content' => base64_encode($content),
         ];
         $this->_inline_attachments[] = $attachment;
-        return $attachment['Filename'];
+        return 'cid:' . $attachment['Filename'];
     }
 
     /**

--- a/Message.php
+++ b/Message.php
@@ -117,6 +117,9 @@ class Message extends BaseMessage {
      * @inheritdoc
      */
     public function setCc($cc) {
+        if (!is_array($cc)){
+            $cc = [$cc => ''];
+        }
         $this->_cc = $cc;
         return $this;
     }
@@ -132,6 +135,9 @@ class Message extends BaseMessage {
      * @inheritdoc
      */
     public function setBcc($bcc) {
+        if (!is_array($bcc)){
+            $bcc = [$bcc => ''];
+        }
         $this->_bcc = $bcc;
         return $this;
     }

--- a/Message.php
+++ b/Message.php
@@ -84,7 +84,7 @@ class Message extends BaseMessage {
      * @inheritdoc
      */
     public function setTo($to) {
-        if (!is_array($to)){
+        if (!is_array($to)) {
             $to = [$to => ''];
         }
         $this->_to = $to;
@@ -117,7 +117,7 @@ class Message extends BaseMessage {
      * @inheritdoc
      */
     public function setCc($cc) {
-        if (!is_array($cc)){
+        if (!is_array($cc)) {
             $cc = [$cc => ''];
         }
         $this->_cc = $cc;

--- a/Message.php
+++ b/Message.php
@@ -186,9 +186,9 @@ class Message extends BaseMessage {
     */
     public function attach($fileName, array $options = []) {
         $attachment = [
-            'ContentType' => isset($options['contentType']) ? $options['contentType'] : \yii\helpers\FileHelper::getMimeType($fileName),
+            'Content-type' => isset($options['Content-type']) ? $options['Content-type'] : \yii\helpers\FileHelper::getMimeType($fileName),
             'Filename' => isset($options['fileName']) ? $options['fileName'] : basename($fileName),
-            'Base64Content' => base64_encode(file_get_contents($fileName)),
+            'content' => base64_encode(file_get_contents($fileName)),
         ];
         $this->_attachments[] = $attachment;
         return $this;
@@ -199,9 +199,9 @@ class Message extends BaseMessage {
     */
     public function attachContent($content, array $options = []) {
         $attachment = [
-            'ContentType' => isset($options['contentType']) ? $options['contentType'] : 'text/plain',
+            'Content-type' => isset($options['Content-type']) ? $options['Content-type'] : 'text/plain',
             'Filename' => isset($options['fileName']) ? $options['fileName'] : 'attachment.txt',
-            'Base64Content' => base64_encode($content),
+            'content' => base64_encode($content),
         ];
         $this->_attachments[] = $attachment;
         return $this;
@@ -212,13 +212,12 @@ class Message extends BaseMessage {
     */
     public function embed($fileName, array $options = []) {
         $attachment = [
-            'ContentType' => isset($options['contentType']) ? $options['contentType'] : \yii\helpers\FileHelper::getMimeType($fileName),
+            'Content-type' => isset($options['Content-type']) ? $options['Content-type'] : \yii\helpers\FileHelper::getMimeType($fileName),
             'Filename' => isset($options['fileName']) ? $options['fileName'] : basename($fileName),
-            'ContentId' => isset($options['id']) ? $options['id'] : crc32(basename($fileName)),
-            'Base64Content' => base64_encode(file_get_contents($fileName)),
+            'content' => base64_encode(file_get_contents($fileName)),
         ];
         $this->_inline_attachments[] = $attachment;
-        return $attachment['ContentId'];
+        return $attachment['Filename'];
     }
 
     /**
@@ -226,13 +225,12 @@ class Message extends BaseMessage {
     */
     public function embedContent($content, array $options = []) {
         $attachment = [
-            'ContentType' => isset($options['contentType']) ? $options['contentType'] : 'text/plain',
+            'Content-type' => isset($options['Content-type']) ? $options['Content-type'] : 'text/plain',
             'Filename' => isset($options['fileName']) ? $options['fileName'] : 'attachment.txt',
-            'ContentId' => isset($options['id']) ? $options['id'] : (isset($options['fileName']) ? crc32($options['fileName']) : crc32(rand(1000,9999).time()) ),
-            'Base64Content' => base64_encode($content),
+            'content' => base64_encode($content),
         ];
         $this->_inline_attachments[] = $attachment;
-        return $attachment['ContentId'];
+        return $attachment['Filename'];
     }
 
     /**

--- a/Message.php
+++ b/Message.php
@@ -17,13 +17,13 @@ class Message extends BaseMessage {
 
     private $_from;
 
-    private $_to;
+    private $_to = [];
 
     private $_replyTo;
 
-    private $_cc;
+    private $_cc = [];
 
-    private $_bcc;
+    private $_bcc = [];
 
     private $_subject;
 

--- a/Message.php
+++ b/Message.php
@@ -31,6 +31,10 @@ class Message extends BaseMessage {
 
     private $_htmlBody;
 
+    private $_attachments;
+
+    private $_inline_attachments;
+
     /**
      * @inheritdoc
      */
@@ -181,28 +185,54 @@ class Message extends BaseMessage {
     * @inheritdoc
     */
     public function attach($fileName, array $options = []) {
-        throw new Exception('Not Implemented');
+        $attachment = [
+            'ContentType' => isset($options['contentType']) ? $options['contentType'] : \yii\helpers\FileHelper::getMimeType($fileName),
+            'Filename' => isset($options['fileName']) ? $options['fileName'] : basename($fileName),
+            'Base64Content' => base64_encode(file_get_contents($fileName)),
+        ];
+        $this->_attachments[] = $attachment;
+        return $this;
     }
 
     /**
     * @inheritdoc
     */
     public function attachContent($content, array $options = []) {
-        throw new Exception('Not Implemented');
+        $attachment = [
+            'ContentType' => isset($options['contentType']) ? $options['contentType'] : 'text/plain',
+            'Filename' => isset($options['fileName']) ? $options['fileName'] : 'attachment.txt',
+            'Base64Content' => base64_encode($content),
+        ];
+        $this->_attachments[] = $attachment;
+        return $this;
     }
 
     /**
     * @inheritdoc
     */
     public function embed($fileName, array $options = []) {
-        throw new Exception('Not Implemented');
+        $attachment = [
+            'ContentType' => isset($options['contentType']) ? $options['contentType'] : \yii\helpers\FileHelper::getMimeType($fileName),
+            'Filename' => isset($options['fileName']) ? $options['fileName'] : basename($fileName),
+            'ContentId' => isset($options['id']) ? $options['id'] : crc32(basename($fileName)),
+            'Base64Content' => base64_encode(file_get_contents($fileName)),
+        ];
+        $this->_inline_attachments[] = $attachment;
+        return $attachment['ContentId'];
     }
 
     /**
     * @inheritdoc
     */
     public function embedContent($content, array $options = []) {
-        throw new Exception('Not Implemented');
+        $attachment = [
+            'ContentType' => isset($options['contentType']) ? $options['contentType'] : 'text/plain',
+            'Filename' => isset($options['fileName']) ? $options['fileName'] : 'attachment.txt',
+            'ContentId' => isset($options['id']) ? $options['id'] : (isset($options['fileName']) ? crc32($options['fileName']) : crc32(rand(1000,9999).time()) ),
+            'Base64Content' => base64_encode($content),
+        ];
+        $this->_inline_attachments[] = $attachment;
+        return $attachment['ContentId'];
     }
 
     /**
@@ -214,4 +244,19 @@ class Message extends BaseMessage {
             . $this->getTextBody();
     }
 
+    /**
+     * @return mixed
+     */
+    public function getAttachments()
+    {
+        return $this->_attachments;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getInlineAttachments()
+    {
+        return $this->_inline_attachments;
+    }
 }


### PR DESCRIPTION
Hello,

I have implemented sending attachments and inline attachments according to [the Mailjet API v3 documentation](https://dev.mailjet.com/guides/#sending-with-attached-files-v3).

`attach`, `attachContent`, `embed` and `embedContent` should be available now.