### PR TITLE
add mailject client as parameter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016 weluse GmbH
+Copyright (c) 2021
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Mailer.php
+++ b/Mailer.php
@@ -53,6 +53,11 @@ class Mailer extends BaseMailer
 
     public function init()
     {
+        if ($this->_mailjet) {
+            // client already defined, no need to new client
+            return;
+        }
+
         if (!$this->_apikey) {
             throw new InvalidConfigException(sprintf('"%s::apikey" cannot be null.', get_class($this)));
         }
@@ -103,6 +108,20 @@ class Mailer extends BaseMailer
             throw new InvalidConfigException(sprintf('"%s::apikey" length should be greater than 0.', get_class($this)));
         }
         $this->_apikey = $trimmedApikey;
+    }
+
+    /**
+     * Sets the Mailjet client
+     *
+     * @param \Mailjet\Client $mailjet the Mailjet Client
+     * @throws InvalidConfigException
+     */
+    public function setMailjet($mailjet)
+    {
+        if (!$mailjet instanceof \Mailjet\Client) {
+            throw new InvalidConfigException(sprintf('"%s::mailjet" should be an instance of \Mailjet\Client, "%s" given.', get_class($this), gettype($mailjet)));
+        }
+        $this->_mailjet = $mailjet;
     }
 
     /**

--- a/Mailer.php
+++ b/Mailer.php
@@ -2,10 +2,10 @@
 /**
  * Contains the Mailer class
  *
- * @package weluse/mailjet
+ * @package Jafarili/mailjet
  */
 
-namespace weluse\mailjet;
+namespace Jafarili\mailjet;
 
 use Mailjet\Resources;
 use yii\base\InvalidConfigException;
@@ -43,7 +43,7 @@ class Mailer extends BaseMailer
     /**
      * @var string message default class name.
      */
-    public $messageClass = 'weluse\mailjet\Message';
+    public $messageClass = 'Jafarili\mailjet\Message';
 
     /**
      *  readonly

--- a/Message.php
+++ b/Message.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace weluse\mailjet;
+namespace Jafarili\mailjet;
 
 use Mailjet\Resources;
 use yii\mail\BaseMessage;
@@ -9,7 +9,7 @@ use yii\base\Exception;
 /**
  * Contains the Message class
  *
- * @package weluse/mailjet
+ * @package Jafarili/mailjet
  */
 class Message extends BaseMessage
 {

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ https://goo.gl/YNWTwd
 ## Install
 
 ```
-composer require weluse/yii2-mailjet
+composer require jafarili/yii2-mailjet
 ```
 
 or add it to your composer.json in the require section
 
 ```
-"weluse/yii2-mailjet": "*",
+"jafarili/yii2-mailjet": "*",
 ```
 
 ## Setup
@@ -23,9 +23,20 @@ add/replace this in your config under the components key.
 ```
 'components' => [
   'mailer' => [
-    'class' => 'weluse\mailjet\Mailer',
+    'class' => 'jafarili\mailjet\Mailer',
     'apikey' => 'yourApiKey',
     'secret' => 'yourSecret',
+  ],
+],
+```
+
+Or set a MailJet client instead:
+
+```
+'components' => [
+  'mailer' => [
+    'class' => 'jafarili\mailjet\Mailer',
+    'mailjet' => new \Mailjet\Client('yourApiKey', 'yourSecret'),
   ],
 ],
 ```
@@ -66,7 +77,7 @@ Write the tracking item to the mailer config.
 ```
 'components' => [
   'mailer' => [
-    'class' => 'weluse\mailjet\Mailer',
+    'class' => 'jafarili\mailjet\Mailer',
     'apikey' => 'yourApiKey',
     'secret' => 'yourSecret',
     'tracking' => [

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ add/replace this in your config under the components key.
 ```
 'components' => [
   'mailer' => [
-    'class' => 'jafarili\mailjet\Mailer',
+    'class' => 'Jafarili\mailjet\Mailer',
     'apikey' => 'yourApiKey',
     'secret' => 'yourSecret',
   ],
@@ -35,7 +35,7 @@ Or set a MailJet client instead:
 ```
 'components' => [
   'mailer' => [
-    'class' => 'jafarili\mailjet\Mailer',
+    'class' => 'Jafarili\mailjet\Mailer',
     'mailjet' => new \Mailjet\Client('yourApiKey', 'yourSecret'),
   ],
 ],
@@ -77,7 +77,7 @@ Write the tracking item to the mailer config.
 ```
 'components' => [
   'mailer' => [
-    'class' => 'jafarili\mailjet\Mailer',
+    'class' => 'Jafarili\mailjet\Mailer',
     'apikey' => 'yourApiKey',
     'secret' => 'yourSecret',
     'tracking' => [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "weluse/yii2-mailjet",
+    "name": "jafarili/yii2-mailjet",
     "description": "Mailjet client",
     "type": "library",
     "require": {
@@ -8,6 +8,6 @@
     "license": "MIT",
     "minimum-stability": "beta",
     "autoload": {
-      "psr-4": { "weluse\\mailjet\\": "" }
+      "psr-4": { "Jafarili\\mailjet\\": "" }
     }
 }


### PR DESCRIPTION
in some cases there's need of passing the mailjet client as a parameter, like when you need to have mailjet client with some extra settings.